### PR TITLE
Allow cmake vars in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,12 @@ COPY . .
 RUN git submodule update --init --recursive
 
 FROM conda as build
+ARG CMAKE_VARS
 WORKDIR /opt/pytorch
 COPY --from=conda /opt/conda /opt/conda
 COPY --from=submodule-update /opt/pytorch /opt/pytorch
 RUN --mount=type=cache,target=/opt/ccache \
+    export eval ${CMAKE_VARS} && \
     TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX 8.0" TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
     CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
     python setup.py install

--- a/README.md
+++ b/README.md
@@ -362,9 +362,17 @@ should increase shared memory size either with `--ipc=host` or `--shm-size` comm
 The `Dockerfile` is supplied to build images with CUDA 11.1 support and cuDNN v8.
 You can pass `PYTHON_VERSION=x.y` make variable to specify which Python version is to be used by Miniconda, or leave it
 unset to use the default.
+
 ```bash
 make -f docker.Makefile
 # images are tagged as docker.io/${your_docker_username}/pytorch
+```
+
+You can also pass the `CMAKE_VARS="..."` make variable to specify additional CMake variables to be passed to CMake during the build. 
+See [setup.py](./setup.py) for the list of available variables.
+
+```bash
+CMAKE_VARS="BUILD_CAFFE2=ON BUILD_CAFFE2_OPS=ON" make -f docker.Makefile
 ```
 
 ### Building the Documentation

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -12,9 +12,6 @@ CUDA_VERSION              = 11.7.0
 CUDNN_VERSION             = 8
 BASE_RUNTIME              = ubuntu:18.04
 BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu18.04
-
-# Will be used when running cmake from setup.py (see script for specific vars)
-# e.g CMAKE_VARS="BUILD_CAFFE2=ON BUILD_CAFFE2_OPS=ON"
 CMAKE_VARS               ?= 
 
 # The conda channel to use to install cudatoolkit

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -13,6 +13,10 @@ CUDNN_VERSION             = 8
 BASE_RUNTIME              = ubuntu:18.04
 BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu18.04
 
+# Will be used when running cmake from setup.py (see script for specific vars)
+# e.g CMAKE_VARS="BUILD_CAFFE2=ON BUILD_CAFFE2_OPS=ON"
+CMAKE_VARS               ?= 
+
 # The conda channel to use to install cudatoolkit
 CUDA_CHANNEL              = nvidia
 # The conda channel to use to install pytorch / torchvision
@@ -31,7 +35,8 @@ BUILD_ARGS                = --build-arg BASE_IMAGE=$(BASE_IMAGE) \
 							--build-arg CUDA_CHANNEL=$(CUDA_CHANNEL) \
 							--build-arg PYTORCH_VERSION=$(PYTORCH_VERSION) \
 							--build-arg INSTALL_CHANNEL=$(INSTALL_CHANNEL) \
-							--build-arg TRITON_VERSION=$(TRITON_VERSION)
+							--build-arg TRITON_VERSION=$(TRITON_VERSION) \
+							--build-arg CMAKE_VARS="$(CMAKE_VARS)"
 EXTRA_DOCKER_BUILD_FLAGS ?=
 
 BUILD                    ?= build


### PR DESCRIPTION
Injects cmake vars for use when building. E.g. we want to include caffe2 in build
Example:

```shell
BUILD_PROGRESS=plain CMAKE_VARS="BUILD_CAFFE2=ON BUILD_CAFFE2_OPS=ON" make -f docker.Makefile
# from docker logs
24 [build 4/4] RUN --mount=type=cache,target=/opt/ccache     export eval BUILD_CAFFE2=ON BUILD_CAFFE2_OPS=ON &&     echo "$BUILD_CAFFE2_OPS $BUILD_CAFFE2" &&     TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX 8.0" TORCH_NVCC_FLAGS="-Xfatbin -compress-all"     CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"     python setup.py install
...
#24 74.72 -- Building Caffe2 modules.
#24 74.73 -- 
#24 74.73 -- ******** Summary ********
#24 74.73 -- General:
#24 74.73 --   CMake version         : 3.22.1
#24 74.73 --   CMake command         : /opt/conda/bin/cmake
#24 74.73 --   System                : Linux
#24 74.73 --   C++ compiler          : /usr/bin/c++
#24 74.73 --   C++ compiler id       : GNU
#24 74.73 --   C++ compiler version  : 7.5.0
#24 74.73 --   Using ccache if found : ON
#24 74.73 --   Found ccache          : /usr/bin/ccache
#24 74.73 --   CXX flags             :  -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -fopenmp -DNDEBUG -DUSE_KINETO -DUSE_FBGEMM -DUSE_QNNPACK -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -DEDGE_PROFILER_USE_KINETO -O2 -fPIC -Wno-narrowing -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wunused-local-typedefs -Wno-unused-parameter -Wno-unused-function -Wno-unused-result -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wno-stringop-overflow -Wno-psabi -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -fdiagnostics-color=always -faligned-new -Wno-unused-but-set-variable -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-stringop-overflow
#24 74.73 --   Build type            : Release
#24 74.73 --   Compile definitions   : ONNX_ML=1;ONNXIFI_ENABLE_EXT=1;ONNX_NAMESPACE=onnx_torch;HAVE_MMAP=1;_FILE_OFFSET_BITS=64;HAVE_SHM_OPEN=1;HAVE_SHM_UNLINK=1;HAVE_MALLOC_USABLE_SIZE=1;USE_EXTERNAL_MZCRC;MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
#24 74.73 --   CMAKE_PREFIX_PATH     : /opt/conda/lib/python3.8/site-packages;/opt/conda/bin/../;/usr/local/cuda
#24 74.73 --   CMAKE_INSTALL_PREFIX  : /opt/pytorch/torch
#24 74.73 --   USE_GOLD_LINKER       : OFF
#24 74.73 -- 
#24 74.73 --   TORCH_VERSION         : 1.13.0
#24 74.73 --   CAFFE2_VERSION        : 1.13.0
#24 74.73 --   BUILD_CAFFE2          : ON
#24 74.73 --   BUILD_CAFFE2_OPS      : ON
#24 74.73 --   BUILD_STATIC_RUNTIME_BENCHMARK: OFF
#24 74.73 --   BUILD_TENSOREXPR_BENCHMARK: OFF
#24 74.73 --   BUILD_NVFUSER_BENCHMARK: OFF
#24 74.73 --   BUILD_BINARY          : OFF
#24 74.73 --   BUILD_CUSTOM_PROTOBUF : ON
#24 74.73 --     Link local protobuf : ON
#24 74.73 --   BUILD_DOCS            : OFF
```